### PR TITLE
Added attributes view in tree view and recursive showing of nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -292,3 +292,6 @@ http-client.private.env.json
 
 # Github Copilot persisted session migrations, see: https://github.com/microsoft/copilot-intellij-feedback/issues/712#issuecomment-3322062215
 .idea/**/copilot.data.migration.*.xml
+
+# Views testing file
+platform/templates/fajl.html

--- a/platform/src/platform/views/graph_visualizer_treeview_view.py
+++ b/platform/src/platform/views/graph_visualizer_treeview_view.py
@@ -1,0 +1,32 @@
+import os
+import sys
+
+
+class TreeView(object):
+    def __init__(self):
+        pass
+
+    def render(self) -> (str, str, str):
+        """
+        Return the html content required for tree view
+        :return: (style, body, script) html string that should be included in page
+        """
+        templates_dir = os.path.join(sys.prefix, 'templates')
+
+        with open(os.path.join(templates_dir, 'graph-visualizer-treeview-style.html'), 'r', encoding='utf-8') as f:
+            style_html = f.read()
+
+        with open(os.path.join(templates_dir, 'graph-visualizer-treeview-body.html'), 'r', encoding='utf-8') as f:
+            body_html = f.read()
+
+        with open(os.path.join(templates_dir, 'graph-visualizer-treeview-script.html'), 'r', encoding='utf-8') as f:
+            script_html = f.read()
+
+        return style_html, body_html, script_html
+
+
+if __name__ == "__main__":
+    style, body, script = TreeView().render()
+    print(style)
+    print(body)
+    print(script)

--- a/platform/templates/graph-visualizer-treeview-script.html
+++ b/platform/templates/graph-visualizer-treeview-script.html
@@ -5,10 +5,15 @@
   const container = document.getElementById('tree-view-content');
   let selectedId  = null;
   let nodeMap     = {};
+  let treeChildren = {};
 
   const CHEVRON = '<svg viewBox="0 0 10 10"><path d="M3 1l4 4-4 4"/></svg>';
-
-  const rendered = new Set();
+  const INTERNAL_ATTR_KEYS = new Set([
+    'id',
+    'index', 'x', 'y', 'vx', 'vy', 'fx', 'fy',
+    '_hw', '_hh', '_dragOffsetX', '_dragOffsetY',
+  ]);
+  const ATTRIBUTE_INDENT_OFFSET = 39;
 
   function buildTree(nodes, links) {
     const byId     = {};
@@ -36,10 +41,48 @@
     return { byId, children, roots };
   }
 
+  function getAttributeEntries(node) {
+    return Object.entries(node).filter(([key, value]) => {
+      if (INTERNAL_ATTR_KEYS.has(key)) return false;
+      if (value == null) return false;
+      const type = typeof value;
+      return type === 'string' || type === 'number' || type === 'boolean';
+    });
+  }
+
+  function renderAttributes(node, depth) {
+    const attrs = getAttributeEntries(node);
+    if (!attrs.length) return null;
+
+    const attrsBox = document.createElement('div');
+    attrsBox.className = 'tv-attrs';
+    attrsBox.style.paddingLeft = (depth * 16 + ATTRIBUTE_INDENT_OFFSET) + 'px';
+
+    attrs.forEach(([key, value]) => {
+      const attrRow = document.createElement('div');
+      attrRow.className = 'tv-attr-row';
+
+      const keyEl = document.createElement('span');
+      keyEl.className = 'tv-attr-key';
+      keyEl.textContent = key + ':';
+      attrRow.appendChild(keyEl);
+
+      const valueEl = document.createElement('span');
+      valueEl.className = 'tv-attr-value';
+      valueEl.textContent = String(value);
+      attrRow.appendChild(valueEl);
+
+      attrsBox.appendChild(attrRow);
+    });
+
+    return attrsBox;
+  }
+
   function renderNode(node, childrenMap, depth) {
-    rendered.add(node.id);
-    const kids    = (childrenMap[node.id] || []).filter(cid => !rendered.has(cid));
-    const isLeaf  = kids.length === 0;
+    const kids    = childrenMap[node.id] || [];
+    const hasChildren = kids.length > 0;
+    const attrsBox = renderAttributes(node, depth);
+    const isLeaf  = !hasChildren && !attrsBox;
     const indent  = depth * 16;
 
     /* row */
@@ -65,7 +108,7 @@
     /* label */
     const label = document.createElement('span');
     label.className = 'tv-label';
-    label.textContent = node.name || node.label || ('node ' + node.id);
+    label.textContent = 'ID: ' + (node.id != null ? String(node.id) : '');
     row.appendChild(label);
 
     const frag = document.createDocumentFragment();
@@ -77,12 +120,21 @@
       childBox = document.createElement('div');
       childBox.className = 'tv-children';
 
-      kids.forEach(cid => {
-        const childNode = nodeMap[cid];
-        if (childNode) {
-          childBox.appendChild(renderNode(childNode, childrenMap, depth + 1));
-        }
-      });
+      if (attrsBox) {
+        childBox.appendChild(attrsBox);
+      }
+
+      const renderChildrenOnce = () => {
+        if (childBox.dataset.childrenRendered === '1') return;
+        childBox.dataset.childrenRendered = '1';
+        kids.forEach(cid => {
+          const childNode = nodeMap[cid];
+          if (childNode) {
+            childBox.appendChild(renderNode(childNode, childrenMap, depth + 1));
+          }
+        });
+      };
+      childBox.__renderChildrenOnce = renderChildrenOnce;
 
       frag.appendChild(childBox);
     }
@@ -90,14 +142,40 @@
     /* toggle expand/collapse */
     toggle.addEventListener('click', (e) => {
       e.stopPropagation();
-      if (isLeaf) return;
+      if (!childBox) return;
+      if (!childBox.classList.contains('tv-open') && typeof childBox.__renderChildrenOnce === 'function') {
+        childBox.__renderChildrenOnce();
+      }
       const open = childBox.classList.toggle('tv-open');
       toggle.classList.toggle('tv-expanded', open);
     });
 
     /* select on row click */
     row.addEventListener('click', () => {
+      const isSameSelected = selectedId === node.id;
+      const isAttrsOpen = row.classList.contains('tv-attrs-open');
+      if (isSameSelected && isAttrsOpen) {
+        row.classList.remove('tv-attrs-open');
+        if (childBox) {
+          const hasChildRows = Array.from(childBox.children)
+            .some(el => el.classList && el.classList.contains('tv-item'));
+          if (!hasChildRows) {
+            childBox.classList.remove('tv-open');
+            toggle.classList.remove('tv-expanded');
+          }
+        }
+        return;
+      }
+
       selectInTree(node.id);
+      if (childBox) {
+        if (typeof childBox.__renderChildrenOnce === 'function') {
+          childBox.__renderChildrenOnce();
+        }
+        childBox.classList.add('tv-open');
+        toggle.classList.add('tv-expanded');
+        row.classList.add('tv-attrs-open');
+      }
       /* notify main view */
       const gv = window.GraphVisualizer;
       if (gv && gv.select) gv.select(node.id);
@@ -115,13 +193,27 @@
 
     if (id == null) return;
 
-    const row = container.querySelector(`.tv-item[data-id="${id}"]`);
+    let row = container.querySelector(`.tv-item[data-id="${id}"]`);
+    if (!row && nodeMap[id]) {
+      container.appendChild(renderNode(nodeMap[id], treeChildren, 0));
+      row = container.querySelector(`.tv-item[data-id="${id}"]`);
+    }
     if (!row) return;
 
     row.classList.add('tv-selected');
 
+    const childBox = row.nextElementSibling;
+    if (childBox && childBox.classList.contains('tv-children')) {
+      if (typeof childBox.__renderChildrenOnce === 'function') {
+        childBox.__renderChildrenOnce();
+      }
+      childBox.classList.add('tv-open');
+      row.classList.add('tv-attrs-open');
+      const rowToggle = row.querySelector('.tv-toggle');
+      if (rowToggle) rowToggle.classList.add('tv-expanded');
+    }
+
     /* auto-expand parents */
-    let el = row.previousElementSibling;
     let parent = row.parentElement;
     while (parent && parent !== container) {
       if (parent.classList.contains('tv-children')) {
@@ -152,20 +244,25 @@
     mount(nodes, links) {
       container.innerHTML = '';
       selectedId = null;
-      rendered.clear();
 
       nodeMap = {};
       nodes.forEach(n => { nodeMap[n.id] = n; });
 
       const tree = buildTree(nodes, links);
+      treeChildren = tree.children;
 
       tree.roots.forEach(root => {
-        if (rendered.has(root.id)) return;
         container.appendChild(renderNode(root, tree.children, 0));
       });
 
       /* auto-expand first level */
       container.querySelectorAll('#tree-view-content > .tv-children').forEach(ch => {
+        if (typeof ch.__renderChildrenOnce === 'function') {
+          ch.__renderChildrenOnce();
+        }
+        const hasChildRows = Array.from(ch.children)
+          .some(el => el.classList && el.classList.contains('tv-item'));
+        if (!hasChildRows) return;
         ch.classList.add('tv-open');
         const prev = ch.previousElementSibling;
         if (prev) {

--- a/platform/templates/graph-visualizer-treeview-style.html
+++ b/platform/templates/graph-visualizer-treeview-style.html
@@ -37,7 +37,6 @@
   padding: 6px 0;
 }
 
-/* scrollbar */
 #tree-view-content::-webkit-scrollbar { width: 6px; }
 #tree-view-content::-webkit-scrollbar-track { background: transparent; }
 #tree-view-content::-webkit-scrollbar-thumb {
@@ -46,7 +45,6 @@
 }
 #tree-view-content::-webkit-scrollbar-thumb:hover { background: #b8a080; }
 
-/* tree item row */
 .tv-item {
   display: flex;
   align-items: center;
@@ -66,7 +64,6 @@
   font-weight: 600;
 }
 
-/* chevron toggle */
 .tv-toggle {
   display: inline-flex;
   align-items: center;
@@ -89,7 +86,6 @@
   visibility: hidden;
 }
 
-/* node icon */
 .tv-icon {
   display: inline-flex;
   align-items: center;
@@ -110,7 +106,6 @@
   box-shadow: 0 0 4px rgba(232,114,12,.5);
 }
 
-/* label */
 .tv-label {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -119,7 +114,40 @@
   line-height: 26px;
 }
 
-/* children container */
+.tv-attrs {
+  display: none;
+  margin: 2px 8px 6px 0;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--hover-bg);
+}
+
+.tv-item.tv-attrs-open + .tv-children.tv-open > .tv-attrs {
+  display: block;
+}
+
+.tv-attr-row {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  min-height: 16px;
+  padding: 1px 6px;
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.tv-attr-key {
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+
+.tv-attr-value {
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+
 .tv-children {
   display: none;
 }

--- a/platform/templates/visualizer-plugin-example.html
+++ b/platform/templates/visualizer-plugin-example.html
@@ -14,6 +14,7 @@
     { source: 1, target: 2 },
     { source: 1, target: 5 },
     { source: 2, target: 3 },
+    { source: 3, target: 2 },
     { source: 2, target: 4 },
     { source: 5, target: 6 },
     { source: 6, target: 1 },


### PR DESCRIPTION
This pull request enhances the graph visualizer's tree view by introducing a feature to display node attributes in the UI, improves the user interaction model for expanding/collapsing nodes, and adds a new Python view class for rendering the tree view. The changes also include style updates to support the new attribute display and a minor update to the example plugin data.

**Tree View Attribute Display and Interaction Improvements:**

* Added logic in the tree view script to display non-internal, non-null node attributes in an expandable section beneath each node. This includes new functions for extracting and rendering these attributes, as well as changes to the expand/collapse and selection behavior to support toggling attribute visibility. [[1]](diffhunk://#diff-5678afad1cf7e04b124fd1daf69be210bdac7c91ec855dfa4c885e8a6427e9a5R8-R16) [[2]](diffhunk://#diff-5678afad1cf7e04b124fd1daf69be210bdac7c91ec855dfa4c885e8a6427e9a5R44-R85) [[3]](diffhunk://#diff-5678afad1cf7e04b124fd1daf69be210bdac7c91ec855dfa4c885e8a6427e9a5L68-R111) [[4]](diffhunk://#diff-5678afad1cf7e04b124fd1daf69be210bdac7c91ec855dfa4c885e8a6427e9a5R123-R178) [[5]](diffhunk://#diff-5678afad1cf7e04b124fd1daf69be210bdac7c91ec855dfa4c885e8a6427e9a5L118-L124) [[6]](diffhunk://#diff-5678afad1cf7e04b124fd1daf69be210bdac7c91ec855dfa4c885e8a6427e9a5L155-R265)
* Updated the tree view styles to support the new attribute box, including styling for attribute rows, keys, and values, and conditional display logic for expanded nodes.

**Codebase and Example Data Updates:**

* Added a new `TreeView` Python class in `graph_visualizer_treeview_view.py` to encapsulate rendering logic for the tree view's HTML components.
* Updated the example plugin data to include a new edge, improving test coverage for cyclic graphs.
