### PR TITLE
Feat/csv plugin

### DIFF
--- a/csv_plugin/csv_plugin/__init__.py
+++ b/csv_plugin/csv_plugin/__init__.py
@@ -1,0 +1,4 @@
+from .csv_datasource_plugin import CsvDataSource
+ 
+__all__ = ["CsvDataSource"]
+ 

--- a/csv_plugin/csv_plugin/csv_datasource_plugin.py
+++ b/csv_plugin/csv_plugin/csv_datasource_plugin.py
@@ -1,0 +1,205 @@
+import csv
+import os
+import sys
+from typing import Any, Dict, List
+
+from api.model.edge import Edge
+from api.model.graph import Graph
+from api.model.node import Node, parse_attribute_value
+from api.plugin.plugin import DataSourcePlugin, PluginParameter
+
+
+class CsvDataSource(DataSourcePlugin):
+    """
+    Data source plugin for parsing CSV files into a Graph object.
+
+    Each row in the CSV represents a node. The file must have a header row.
+    The 'id' column is required and must be unique across all rows.
+    The optional 'parent_id' column creates a directed edge from the parent node to this node.
+    All other columns are treated as node attributes.
+    The load() function takes the filename of the CSV file that is in the platform data folder.
+
+    Rules:
+    1. The CSV file must have a header row.
+    2. Each row must have a non-empty 'id' field — this is the node identifier.
+    3. If a row has a non-empty 'parent_id' that matches another row's 'id',
+       a directed edge is created: parent → child.
+    4. If 'parent_id' points to a non-existent 'id', the reference is silently ignored.
+    5. Empty cells are ignored and do not become node attributes.
+    6. Attribute types are inferred automatically: int, float, date (ISO format), or str.
+    7. Allowed attribute types: int, float, str, date (ISO format, e.g., 2026-03-12).
+    8. Duplicate 'id' values: the first occurrence is kept; subsequent rows with
+       the same 'id' are silently skipped.
+
+    Expected CSV structure:
+
+        id,parent_id,name,value,created
+        root,,Root Node,100,2026-03-12
+        child1,root,Child One,42,2026-01-15
+        child2,root,Child Two,3.14,
+        grandchild1,child1,Grandchild,7,
+
+    Example interpretation:
+    - 'root' has no parent; attributes: name="Root Node", value=100, created=2026-03-12.
+    - 'child1' and 'child2' are children of 'root' (edges: root→child1, root→child2).
+    - 'grandchild1' is a child of 'child1' (edge: child1→grandchild1).
+    """
+
+    # Column names with special meaning — never treated as attributes
+    _RESERVED_COLUMNS = {"id", "parent_id"}
+
+    def __init__(self):
+        """
+        Initializes the CsvDataSource plugin.
+
+        Sets up an empty Graph and a counter for generating unique edge IDs.
+        Node IDs are taken directly from the CSV 'id' column, so no separate
+        mapping is needed.
+        """
+        self._graph: Graph = Graph("why_does_the_graph_need_an_id", "csv_graph")
+        self._edge_counter = 1
+
+    def get_name(self) -> str:
+        """
+        Returns the human-readable name of the plugin.
+
+        Returns:
+            str: Name of the plugin.
+        """
+        return "CsvDataSource"
+
+    def get_parameters(self) -> List[PluginParameter]:
+        """
+        Returns the list of input parameters required by the plugin.
+
+        This is used by the platform to generate input forms automatically.
+
+        Returns:
+            List[PluginParameter]: List containing a single parameter for the CSV file name.
+        """
+        return [
+            PluginParameter(
+                name="file_name",
+                label="Full name of the file in the platform data directory",
+                required=True,
+            )
+        ]
+
+    def load(self, params: Dict[str, Any]) -> Graph:
+        """
+        Loads and parses the CSV file into a Graph object.
+
+        Performs two passes over the rows:
+        1. First pass — creates all nodes and their attributes.
+        2. Second pass — resolves 'parent_id' references and creates edges.
+
+        Args:
+            params (Dict[str, Any]): Dictionary containing plugin parameters.
+                Must contain 'file_name'.
+
+        Returns:
+            Graph: The populated graph representing the CSV structure.
+
+        Raises:
+            ValueError: If a row is missing a non-empty 'id' field.
+            FileNotFoundError: If the specified CSV file does not exist.
+        """
+        self._graph = Graph(params["file_name"], "csv_graph")
+        self._edge_counter = 1
+
+        data_dir = os.path.join(sys.prefix, "data")
+        file_path = os.path.join(data_dir, params["file_name"])
+
+        with open(file_path, newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+
+        # First pass: build all nodes
+        for row in rows:
+            self._build_node_and_add_to_graph(row)
+
+        # Second pass: connect nodes via parent_id
+        self._connect_parents(rows)
+
+        return self._graph
+
+    def _build_node_and_add_to_graph(self, row: Dict[str, str]) -> Node:
+        """
+        Converts a single CSV row into a Node and adds it to the graph.
+
+        Skips the row silently if a node with the same 'id' already exists
+        (i.e., duplicate IDs are handled by keeping the first occurrence).
+
+        Args:
+            row (Dict[str, str]): A dictionary representing one CSV row,
+                keyed by column header names.
+
+        Returns:
+            Node: The created (or pre-existing) Node for this row's 'id'.
+
+        Raises:
+            ValueError: If the row's 'id' cell is missing or empty.
+        """
+        node_id = str(row.get("id") or "").strip()
+        if not node_id:
+            raise ValueError(
+                "Each CSV row must have a non-empty 'id' field."
+            )
+
+        # Duplicate id → silently return the existing node (first-wins policy)
+        if self._graph.has_node(node_id):
+            return self._graph.get_node(node_id)
+
+        node = Node(node_id)
+        self._graph.add_node(node)
+
+        for key, value in row.items():
+            if key in self._RESERVED_COLUMNS:
+                continue
+            if value is None or str(value).strip() == "":
+                continue
+            node.set_attribute(key, parse_attribute_value(str(value).strip()))
+
+        return node
+
+    def _connect_parents(self, rows: List[Dict[str, str]]) -> None:
+        """
+        Creates edges based on 'parent_id' references in each row.
+
+        For each row that contains a non-empty 'parent_id', looks up both
+        the parent node and the child node in the graph, then creates a
+        directed edge from parent to child. Invalid references (pointing to
+        an 'id' that does not exist in the graph) are silently ignored.
+
+        Args:
+            rows (List[Dict[str, str]]): All rows from the CSV file.
+        """
+        for row in rows:
+            parent_id = str(row.get("parent_id") or "").strip()
+            child_id = str(row.get("id") or "").strip()
+
+            if not parent_id or not child_id:
+                continue
+
+            if not self._graph.has_node(parent_id) or not self._graph.has_node(child_id):
+                continue
+
+            parent = self._graph.get_node(parent_id)
+            child = self._graph.get_node(child_id)
+            self._build_edge_and_add_to_graph(parent, child)
+
+    def _build_edge_and_add_to_graph(self, src: Node, des: Node) -> Edge:
+        """
+        Creates an Edge from src to des and adds it to the graph.
+
+        Args:
+            src (Node): The source node.
+            des (Node): The target node.
+
+        Returns:
+            Edge: The created Edge object.
+        """
+        edge = Edge(str(self._edge_counter), src, des)
+        self._graph.add_edge(edge)
+        self._edge_counter += 1
+        return edge

--- a/csv_plugin/csv_plugin/csv_datasource_plugin_test.py
+++ b/csv_plugin/csv_plugin/csv_datasource_plugin_test.py
@@ -1,0 +1,363 @@
+import csv
+import io
+import unittest
+from unittest.mock import mock_open, patch
+
+from csv_plugin.csv_datasource_plugin import CsvDataSource
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def build_csv(rows: list[dict], fieldnames: list[str] | None = None) -> str:
+    """Serializes a list of dicts to a CSV string with a header row."""
+    if not rows:
+        return ""
+    if fieldnames is None:
+        fieldnames = list(rows[0].keys())
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=fieldnames, extrasaction="ignore")
+    writer.writeheader()
+    writer.writerows(rows)
+    return buf.getvalue()
+
+
+def make_graph(csv_string: str):
+    """Loads a Graph from a raw CSV string by mocking the file open call."""
+    mock_file = mock_open(read_data=csv_string)
+    with patch("builtins.open", mock_file):
+        ds = CsvDataSource()
+        return ds.load({"file_name": "fake.csv"})
+
+
+# ---------------------------------------------------------------------------
+# Fixture data
+# ---------------------------------------------------------------------------
+
+CSV_BASIC = build_csv([
+    {"id": "root",       "parent_id": "",      "name": "Root Node", "value": "100",  "created": "2026-03-12"},
+    {"id": "child1",     "parent_id": "root",  "name": "Child One", "value": "42",   "created": "2026-01-15"},
+    {"id": "child2",     "parent_id": "root",  "name": "Child Two", "value": "3.14", "created": ""},
+    {"id": "grandchild1","parent_id": "child1","name": "Grandchild","value": "7",    "created": ""},
+])
+
+CSV_NO_PARENT = build_csv([
+    {"id": "root",  "name": "Root", "value": "1"},
+    {"id": "alpha", "name": "A",    "value": "2"},
+    {"id": "beta",  "name": "B",    "value": "3"},
+])
+
+CSV_INVALID_PARENT = build_csv([
+    {"id": "orphan", "parent_id": "nonexistent", "name": "Orphan"},
+])
+
+CSV_DUPLICATE_IDS = build_csv([
+    {"id": "same", "parent_id": "",     "value": "1"},
+    {"id": "same", "parent_id": "",     "value": "2"},   # duplicate — skipped
+    {"id": "other","parent_id": "same", "value": "3"},
+])
+
+CSV_MISSING_ID = build_csv([
+    {"id": "",     "name": "No ID Here"},
+    {"id": "valid","name": "Valid"},
+])
+
+CSV_EMPTY_CELLS = build_csv([
+    {"id": "node", "parent_id": "", "a": "10", "b": "", "c": "   ", "d": "hello"},
+])
+
+CSV_DEEP = build_csv([
+    {"id": "l1", "parent_id": "",   "depth": "1"},
+    {"id": "l2", "parent_id": "l1", "depth": "2"},
+    {"id": "l3", "parent_id": "l2", "depth": "3"},
+    {"id": "l4", "parent_id": "l3", "depth": "4"},
+    {"id": "l5", "parent_id": "l4", "depth": "5"},
+])
+
+CSV_MULTIPLE_CHILDREN = build_csv([
+    {"id": "parent", "parent_id": "",       "label": "Parent"},
+    {"id": "c1",     "parent_id": "parent", "label": "C1"},
+    {"id": "c2",     "parent_id": "parent", "label": "C2"},
+    {"id": "c3",     "parent_id": "parent", "label": "C3"},
+])
+
+CSV_TYPES = build_csv([
+    {"id": "types", "parent_id": "",
+     "int_val": "42", "float_val": "3.14", "str_val": "hello",
+     "date_val": "2026-03-12", "empty_val": "", "whitespace_val": "   "},
+])
+
+CSV_SELF_REF = build_csv([
+    {"id": "self", "parent_id": "self", "value": "5"},
+])
+
+CSV_EMPTY = "id,parent_id,name\n"   # header only, no data rows
+
+CSV_NO_PARENT_COL = build_csv([
+    {"id": "a", "name": "Alpha"},
+    {"id": "b", "name": "Beta"},
+])
+
+CSV_MULTIPLE_ROOTS = build_csv([
+    {"id": "root1", "parent_id": "",      "label": "Root 1"},
+    {"id": "root2", "parent_id": "",      "label": "Root 2"},
+    {"id": "child", "parent_id": "root1", "label": "Child"},
+])
+
+
+# ===========================================================================
+# Test suites
+# ===========================================================================
+
+class TestCsvDataSourceNodes(unittest.TestCase):
+
+    def test_basic_node_count(self):
+        graph = make_graph(CSV_BASIC)
+        self.assertEqual(len(list(graph.nodes())), 4)
+
+    def test_root_attributes(self):
+        graph = make_graph(CSV_BASIC)
+        root = graph.get_node("root")
+        self.assertIsNotNone(root)
+        self.assertEqual(root.get_attribute("name"), "Root Node")
+        self.assertEqual(root.get_attribute("value"), 100)
+
+        from datetime import date
+        self.assertIsInstance(root.get_attribute("created"), date)
+        self.assertEqual(str(root.get_attribute("created")), "2026-03-12")
+
+    def test_child1_attributes(self):
+        graph = make_graph(CSV_BASIC)
+        node = graph.get_node("child1")
+        self.assertEqual(node.get_attribute("value"), 42)
+        self.assertEqual(node.get_attribute("name"), "Child One")
+
+    def test_child2_float_attribute(self):
+        graph = make_graph(CSV_BASIC)
+        node = graph.get_node("child2")
+        self.assertAlmostEqual(node.get_attribute("value"), 3.14)
+
+    def test_grandchild_attributes(self):
+        graph = make_graph(CSV_BASIC)
+        node = graph.get_node("grandchild1")
+        self.assertEqual(node.get_attribute("value"), 7)
+
+    def test_node_ids_are_unique(self):
+        graph = make_graph(CSV_BASIC)
+        ids = [n.node_id for n in graph.nodes()]
+        self.assertEqual(len(ids), len(set(ids)))
+
+    def test_no_parent_column_all_nodes_created(self):
+        graph = make_graph(CSV_NO_PARENT_COL)
+        self.assertEqual(len(list(graph.nodes())), 2)
+
+    def test_multiple_roots(self):
+        graph = make_graph(CSV_MULTIPLE_ROOTS)
+        self.assertEqual(len(list(graph.nodes())), 3)
+
+    def test_empty_file_no_nodes(self):
+        graph = make_graph(CSV_EMPTY)
+        self.assertEqual(len(list(graph.nodes())), 0)
+        self.assertEqual(len(list(graph.edges())), 0)
+
+    def test_deep_nesting_node_count(self):
+        graph = make_graph(CSV_DEEP)
+        self.assertEqual(len(list(graph.nodes())), 5)
+
+    def test_attribute_type_int(self):
+        graph = make_graph(CSV_TYPES)
+        node = graph.get_node("types")
+        self.assertIsInstance(node.get_attribute("int_val"), int)
+        self.assertEqual(node.get_attribute("int_val"), 42)
+
+    def test_attribute_type_float(self):
+        graph = make_graph(CSV_TYPES)
+        node = graph.get_node("types")
+        self.assertIsInstance(node.get_attribute("float_val"), float)
+        self.assertAlmostEqual(node.get_attribute("float_val"), 3.14)
+
+    def test_attribute_type_str(self):
+        graph = make_graph(CSV_TYPES)
+        node = graph.get_node("types")
+        self.assertIsInstance(node.get_attribute("str_val"), str)
+        self.assertEqual(node.get_attribute("str_val"), "hello")
+
+    def test_attribute_type_date(self):
+        from datetime import date
+        graph = make_graph(CSV_TYPES)
+        node = graph.get_node("types")
+        self.assertIsInstance(node.get_attribute("date_val"), date)
+        self.assertEqual(str(node.get_attribute("date_val")), "2026-03-12")
+
+
+class TestCsvDataSourceEdges(unittest.TestCase):
+
+    def test_basic_edge_count(self):
+        graph = make_graph(CSV_BASIC)
+        self.assertEqual(len(list(graph.edges())), 3)
+
+    def test_root_to_child1_edge(self):
+        graph = make_graph(CSV_BASIC)
+        root   = graph.get_node("root")
+        child1 = graph.get_node("child1")
+        edges  = list(graph.edges())
+        self.assertTrue(any(e.source == root and e.target == child1 for e in edges))
+
+    def test_root_to_child2_edge(self):
+        graph = make_graph(CSV_BASIC)
+        root   = graph.get_node("root")
+        child2 = graph.get_node("child2")
+        edges  = list(graph.edges())
+        self.assertTrue(any(e.source == root and e.target == child2 for e in edges))
+
+    def test_child1_to_grandchild_edge(self):
+        graph = make_graph(CSV_BASIC)
+        child1      = graph.get_node("child1")
+        grandchild1 = graph.get_node("grandchild1")
+        edges = list(graph.edges())
+        self.assertTrue(any(e.source == child1 and e.target == grandchild1 for e in edges))
+
+    def test_no_parent_column_no_edges(self):
+        graph = make_graph(CSV_NO_PARENT_COL)
+        self.assertEqual(len(list(graph.edges())), 0)
+
+    def test_no_parent_id_values_no_edges(self):
+        graph = make_graph(CSV_NO_PARENT)
+        self.assertEqual(len(list(graph.edges())), 0)
+
+    def test_invalid_parent_ref_ignored(self):
+        try:
+            graph = make_graph(CSV_INVALID_PARENT)
+            self.assertEqual(len(list(graph.edges())), 0)
+            self.assertEqual(len(list(graph.nodes())), 1)
+        except Exception as e:
+            self.fail(f"Invalid parent_id raised an exception: {e}")
+
+    def test_multiple_children_edges(self):
+        graph = make_graph(CSV_MULTIPLE_CHILDREN)
+        parent = graph.get_node("parent")
+        edges  = list(graph.edges())
+        out_edges = [e for e in edges if e.source == parent]
+        self.assertEqual(len(out_edges), 3)
+
+    def test_deep_nesting_edge_count(self):
+        graph = make_graph(CSV_DEEP)
+        self.assertEqual(len(list(graph.edges())), 4)
+
+    def test_deep_nesting_chain(self):
+        graph = make_graph(CSV_DEEP)
+        edges = list(graph.edges())
+        pairs = [(e.source.node_id, e.target.node_id) for e in edges]
+        self.assertIn(("l1", "l2"), pairs)
+        self.assertIn(("l2", "l3"), pairs)
+        self.assertIn(("l3", "l4"), pairs)
+        self.assertIn(("l4", "l5"), pairs)
+
+    def test_multiple_roots_correct_edges(self):
+        graph = make_graph(CSV_MULTIPLE_ROOTS)
+        root1 = graph.get_node("root1")
+        child = graph.get_node("child")
+        edges = list(graph.edges())
+        self.assertEqual(len(edges), 1)
+        self.assertTrue(any(e.source == root1 and e.target == child for e in edges))
+
+    def test_self_reference_creates_self_loop(self):
+        try:
+            graph = make_graph(CSV_SELF_REF)
+            edges = list(graph.edges())
+            self.assertTrue(any(e.source == e.target for e in edges))
+        except Exception as e:
+            self.fail(f"Self-referencing parent_id raised an exception: {e}")
+
+
+class TestCsvDataSourceReturnType(unittest.TestCase):
+
+    def test_load_returns_graph(self):
+        from api.model.graph import Graph
+        graph = make_graph(CSV_BASIC)
+        self.assertIsInstance(graph, Graph)
+
+    def test_nodes_returns_iterable(self):
+        graph = make_graph(CSV_BASIC)
+        self.assertTrue(hasattr(graph.nodes(), "__iter__"))
+
+    def test_edges_returns_iterable(self):
+        graph = make_graph(CSV_BASIC)
+        self.assertTrue(hasattr(graph.edges(), "__iter__"))
+
+
+class TestCsvDataSourceEdgeCases(unittest.TestCase):
+
+    def test_empty_and_whitespace_cells_ignored(self):
+        graph = make_graph(CSV_EMPTY_CELLS)
+        node = graph.get_node("node")
+        self.assertEqual(node.get_attribute("a"), 10)
+        self.assertEqual(node.get_attribute("d"), "hello")
+        self.assertNotIn("b", node.attributes)
+        self.assertNotIn("c", node.attributes)
+
+    def test_missing_id_raises_value_error(self):
+        with self.assertRaises(ValueError) as ctx:
+            make_graph(CSV_MISSING_ID)
+        self.assertIn("non-empty 'id'", str(ctx.exception))
+
+    def test_duplicate_ids_first_wins(self):
+        graph = make_graph(CSV_DUPLICATE_IDS)
+        nodes = list(graph.nodes())
+        # Only 2 unique nodes: "same" and "other"
+        self.assertEqual(len(nodes), 2)
+        same_node = graph.get_node("same")
+        # First occurrence has value=1
+        self.assertEqual(same_node.get_attribute("value"), 1)
+
+    def test_reserved_columns_not_attributes(self):
+        graph = make_graph(CSV_BASIC)
+        for node in graph.nodes():
+            self.assertNotIn("id",        node.attributes)
+            self.assertNotIn("parent_id", node.attributes)
+
+    def test_empty_csv_header_only(self):
+        graph = make_graph(CSV_EMPTY)
+        self.assertEqual(len(list(graph.nodes())), 0)
+        self.assertEqual(len(list(graph.edges())), 0)
+
+    def test_load_resets_state_between_calls(self):
+        """Calling load() twice should not accumulate nodes/edges."""
+        mock_file = mock_open(read_data=CSV_BASIC)
+        with patch("builtins.open", mock_file):
+            ds = CsvDataSource()
+            ds.load({"file_name": "fake.csv"})
+            graph = ds.load({"file_name": "fake.csv"})
+
+        self.assertEqual(len(list(graph.nodes())), 4)
+        self.assertEqual(len(list(graph.edges())), 3)
+
+    def test_node_with_no_attributes_created(self):
+        csv_str = build_csv([
+            {"id": "bare", "parent_id": ""},
+        ])
+        graph = make_graph(csv_str)
+        self.assertIsNotNone(graph.get_node("bare"))
+
+    def test_large_number_of_nodes(self):
+        rows = [{"id": f"node_{i}", "parent_id": f"node_{i-1}" if i > 0 else "", "value": str(i)}
+                for i in range(100)]
+        csv_str = build_csv(rows)
+        graph = make_graph(csv_str)
+        self.assertEqual(len(list(graph.nodes())), 100)
+        self.assertEqual(len(list(graph.edges())), 99)
+
+    def test_integer_id_treated_as_string(self):
+        csv_str = build_csv([
+            {"id": "1", "parent_id": "", "name": "One"},
+            {"id": "2", "parent_id": "1", "name": "Two"},
+        ])
+        graph = make_graph(csv_str)
+        self.assertIsNotNone(graph.get_node("1"))
+        self.assertIsNotNone(graph.get_node("2"))
+        self.assertEqual(len(list(graph.edges())), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/csv_plugin/pyproject.toml
+++ b/csv_plugin/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "graph-visualizer-datasource-csv"
+version = "1.0.0"
+requires-python = ">=3.11"
+dependencies = [
+    "graph-api"
+]
+
+[project.entry-points."graph.data_source"]
+datasource_csv = "csv_plugin.csv_datasource_plugin:CsvDataSource"
+
+[tool.setuptools.packages.find]
+where = ["."]


### PR DESCRIPTION
## Description
Implements the CsvDataSource plugin that parses CSV files into a Graph object. This is a concrete implementation of the DataSourcePlugin abstract base class, following the same plugin architecture established by the XML and JSON datasource plugins.

## Changes
- **csv_datasource_plugin.py**: Core CsvDataSource implementation
  - Parses CSV rows as graph nodes with automatic attribute type inference (`int`, `float`, `date`, `str`)
  - Creates directed edges from `parent_id` column references
  - Two-pass loading: first creates all nodes, then resolves parent references
  - Silently ignores invalid `parent_id` references and duplicate `id` values (first-wins)
  - Skips empty and whitespace-only cells as attributes
  - Reserves `id` and `parent_id` columns — never treated as node attributes

- **__init__.py**: Exports `CsvDataSource` for package consumers

- **pyproject.toml**: Configures package discovery and entry point registration
  - Registered plugin under `graph.data_source` entry point group

- **csv_datasource_plugin_test.py**: Comprehensive unit test suite (30 test cases)
  - Node creation: count, attributes, type inference (`int`, `float`, `date`, `str`)
  - Edge creation: parent-child, multiple children, deep nesting, chain validation
  - Return type validation: `Graph`, iterable `nodes()` and `edges()`
  - Edge cases: empty CSV, missing `id`, duplicate `id`, invalid `parent_id`, self-reference, reserved columns, state reset between calls, large graphs (100 nodes)

## Technical Details
- Uses Python's built-in `csv.DictReader` — no external dependencies
- Two-pass approach ensures correct edge resolution regardless of row ordering
- Platform-agnostic: no Django/Flask dependencies

## Testing
```bash
pytest csv_plugin/csv_plugin/csv_datasource_plugin_test.py -v
# Result: 38 passed ✓
```

Relates to #35 