### PR TITLE
Fixed json plugin for cyclic graphs

### DIFF
--- a/json_plugin/json_plugin/json_datasource_plugin.py
+++ b/json_plugin/json_plugin/json_datasource_plugin.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Set
 
 from api.model.edge import Edge
 from api.model.graph import Graph
@@ -53,7 +53,8 @@ class JsonDataSource(DataSourcePlugin):
     1. Each object must have a non-empty "id".
     2. The LAST key in the object, if it's a list of objects, is treated as children
        and creates directed edges parent -> child. The key name does not matter.
-    3. All other primitive fields are node attributes.
+        3. Scalar fields are stored as attributes and are also treated as references if
+             they match another node ID (or an ID suffix alias like "server:1" -> "1").
     4. String attributes are parsed with parse_attribute_value (int/float/date fallback).
     5. Allowed attribute types: int, float, str, date (ISO format, e.g., 2026-03-12).
     6. None, empty strings, and nested objects/lists (except children) are ignored as attributes.
@@ -100,6 +101,9 @@ class JsonDataSource(DataSourcePlugin):
         self._graph: Graph = Graph("why_does_the_graph_need_an_id", "json_graph")
         self._node_counter = 1
         self._edge_counter = 1
+        self._node_reference_map: Dict[Node, List[str]] = {}
+        self._id_alias_map: Dict[str, Node] = {}
+        self._ambiguous_aliases: Set[str] = set()
 
     def get_name(self) -> str:
         """
@@ -143,6 +147,9 @@ class JsonDataSource(DataSourcePlugin):
         self._graph = Graph(params["file_name"], "json_graph")
         self._node_counter = 1
         self._edge_counter = 1
+        self._node_reference_map = {}
+        self._id_alias_map = {}
+        self._ambiguous_aliases = set()
 
         file_path = _resolve_platform_data_file(params["file_name"])
 
@@ -153,6 +160,7 @@ class JsonDataSource(DataSourcePlugin):
             raise ValueError("Root JSON value must be an object representing a node.")
 
         self._build_node_and_add_to_graph(data)
+        self._connect_references()
         return self._graph
 
     def _build_node_and_add_to_graph(self, json_node: Dict[str, Any]) -> Node:
@@ -183,6 +191,7 @@ class JsonDataSource(DataSourcePlugin):
 
         node = Node(node_id)
         self._graph.add_node(node)
+        self._register_node_aliases(node)
 
         keys = list(json_node.keys())
         last_key = keys[-1] if keys else None
@@ -199,13 +208,21 @@ class JsonDataSource(DataSourcePlugin):
             children = last_value
             children_key = last_key
 
+        reference_tokens: List[str] = []
+
         for key, value in json_node.items():
             if key in {"id"} or key == children_key:
                 continue
+
+            reference_tokens.extend(self._extract_reference_tokens(value))
+
             converted = self._convert_attribute_value(value)
             if converted is None:
                 continue
             node.set_attribute(key, converted)
+
+        if reference_tokens:
+            self._node_reference_map[node] = reference_tokens
 
         for child_json in children:
             child_node = self._build_node_and_add_to_graph(child_json)
@@ -262,6 +279,71 @@ class JsonDataSource(DataSourcePlugin):
         if isinstance(value, (dict, list)):
             return None
         return str(value)
+
+    def _register_node_aliases(self, node: Node) -> None:
+        aliases = {node.node_id}
+        if ":" in node.node_id:
+            suffix = node.node_id.rsplit(":", 1)[-1].strip()
+            if suffix:
+                aliases.add(suffix)
+
+        for alias in aliases:
+            if alias in self._ambiguous_aliases:
+                continue
+
+            existing = self._id_alias_map.get(alias)
+            if existing is None or existing == node:
+                self._id_alias_map[alias] = node
+                continue
+
+            self._id_alias_map.pop(alias, None)
+            self._ambiguous_aliases.add(alias)
+
+    def _extract_reference_tokens(self, value: Any) -> List[str]:
+        if value is None or isinstance(value, bool):
+            return []
+
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return []
+            return [part.strip() for part in stripped.split(",") if part.strip()]
+
+        if isinstance(value, dict):
+            reference_tokens: List[str] = []
+            for wrapper_key in ("ref", "refs"):
+                if wrapper_key not in value:
+                    continue
+
+                wrapper_value = value.get(wrapper_key)
+                if isinstance(wrapper_value, list):
+                    for item in wrapper_value:
+                        reference_tokens.extend(self._extract_reference_tokens(item))
+                else:
+                    reference_tokens.extend(self._extract_reference_tokens(wrapper_value))
+
+            return reference_tokens
+
+        return []
+
+    def _resolve_reference_node(self, reference_token: str):
+        token = str(reference_token).strip()
+        if not token:
+            return None
+
+        direct_match = self._graph.get_node(token)
+        if direct_match is not None:
+            return direct_match
+
+        return self._id_alias_map.get(token)
+
+    def _connect_references(self) -> None:
+        for source_node, reference_tokens in self._node_reference_map.items():
+            for reference_token in reference_tokens:
+                target_node = self._resolve_reference_node(reference_token)
+                if target_node is None:
+                    continue
+                self._build_edge_and_add_to_graph(source_node, target_node)
 
     def _build_edge_and_add_to_graph(self, src: Node, des: Node) -> Edge:
         """

--- a/json_plugin/json_plugin/json_datasource_plugin_test.py
+++ b/json_plugin/json_plugin/json_datasource_plugin_test.py
@@ -111,6 +111,92 @@ TEST_JSON_SELF_REFERENCE = {
     "value": 10
 }
 
+TEST_JSON_CYCLIC = {
+    "id": "network",
+    "children": [
+        {
+            "id": "server:1",
+            "type": "Server",
+            "ip": "192.168.1.1",
+            "port": 8080,
+            "connectsTo": "2",
+            "connections": "5"
+        },
+        {
+            "id": "database:2",
+            "type": "Database",
+            "dbType": "PostgreSQL",
+            "port": 5432,
+            "replicatesTo": "3",
+            "backupTarget": "1"
+        },
+        {
+            "id": "cache:3",
+            "type": "Cache",
+            "cacheType": "Redis",
+            "port": 6379,
+            "dependsOn": "2",
+            "peer": "1"
+        },
+        {
+            "id": "api:4",
+            "type": "API",
+            "name": "REST API",
+            "language": "Python",
+            "calls": "5"
+        },
+        {
+            "id": "worker:5",
+            "type": "Worker",
+            "name": "Task Worker",
+            "language": "Python",
+            "queue": "celery",
+            "registeredIn": "4",
+            "task": "6"
+        },
+        {
+            "id": "mq:6",
+            "type": "MessageQueue",
+            "name": "RabbitMQ",
+            "mqType": "AMQP",
+            "port": 5672,
+            "usedBy": "5",
+            "consumesFrom": "1"
+        },
+        {
+            "id": "monitor:7",
+            "type": "Monitor",
+            "name": "Self Monitor",
+            "interval": 30,
+            "selfRef": "7",
+            "monitorTarget": "7"
+        },
+        {
+            "id": "loadbalancer:8",
+            "type": "LoadBalancer",
+            "name": "HAProxy",
+            "routesTo": "9",
+            "backend": "10"
+        },
+        {
+            "id": "webserver:9",
+            "type": "WebServer",
+            "name": "Nginx",
+            "port": 80,
+            "proxiesTo": "4",
+            "upstream": "8"
+        },
+        {
+            "id": "appserver:10",
+            "type": "AppServer",
+            "name": "Gunicorn",
+            "workers": 4,
+            "connectsTo": "8",
+            "app": "9"
+        }
+    ]
+}
+
 def make_graph(json_data):
     mock_file = mock_open(read_data=json.dumps(json_data))
     with patch("builtins.open", mock_file):
@@ -282,11 +368,43 @@ class TestJsonDataSourceEdgeCases(unittest.TestCase):
         self.assertEqual(len(nodes), 1)
         self.assertEqual(len(edges), 0)
 
-    def test_self_reference_no_cycle(self):
+    def test_self_reference_creates_self_loop(self):
         graph = make_graph(TEST_JSON_SELF_REFERENCE)
         node = graph.get_node("self")
         edges = list(graph.edges())
-        self.assertEqual(len(edges), 0)
+        self.assertEqual(len(edges), 1)
+        self.assertTrue(any(e.source == node and e.target == node for e in edges))
+
+    def test_suffix_alias_reference_creates_edge(self):
+        json_data = {
+            "id": "root",
+            "children": [
+                {"id": "server:1", "connectsTo": "2"},
+                {"id": "database:2", "type": "Database"}
+            ]
+        }
+        graph = make_graph(json_data)
+
+        server = graph.get_node("server:1")
+        database = graph.get_node("database:2")
+        edges = list(graph.edges())
+        self.assertTrue(any(e.source == server and e.target == database for e in edges))
+
+    def test_cyclic_graph_edges_from_scalar_references(self):
+        graph = make_graph(TEST_JSON_CYCLIC)
+        nodes = list(graph.nodes())
+        edges = list(graph.edges())
+
+        self.assertEqual(len(nodes), 11)
+        self.assertEqual(len(edges), 29)
+
+        monitor = graph.get_node("monitor:7")
+        self_loops = [e for e in edges if e.source == monitor and e.target == monitor]
+        self.assertEqual(len(self_loops), 2)
+
+        server = graph.get_node("server:1")
+        database = graph.get_node("database:2")
+        self.assertTrue(any(e.source == server and e.target == database for e in edges))
 
     def test_non_last_key_as_children_ignored(self):
         json_data = {


### PR DESCRIPTION
This pull request significantly enhances the JSON data source plugin by adding support for automatically detecting and connecting references between nodes based on scalar attribute values, including support for ID suffix aliases (e.g., `"server:1"` can be referenced as `"1"`). It also introduces robust handling of ambiguous aliases and self-references, and expands the test suite to cover these new behaviors.

**Improvements to reference detection and graph construction:**

* Scalar fields in node objects are now treated as references if their values match another node's ID or a recognized ID suffix alias, enabling automatic edge creation between related nodes. This includes the ability to reference nodes using only their suffix (e.g., `"1"` for `"server:1"`). [[1]](diffhunk://#diff-e1cc949d392fedd14f93010706c76ae4e565c06111e49ae3ede36e1bdfc08ac8L56-R57) [[2]](diffhunk://#diff-e1cc949d392fedd14f93010706c76ae4e565c06111e49ae3ede36e1bdfc08ac8R211-R226) [[3]](diffhunk://#diff-e1cc949d392fedd14f93010706c76ae4e565c06111e49ae3ede36e1bdfc08ac8R283-R347)
* Added internal alias and reference tracking via `_id_alias_map`, `_ambiguous_aliases`, and `_node_reference_map` to manage node lookups, handle ambiguous aliases, and collect references for edge creation. [[1]](diffhunk://#diff-e1cc949d392fedd14f93010706c76ae4e565c06111e49ae3ede36e1bdfc08ac8R104-R106) [[2]](diffhunk://#diff-e1cc949d392fedd14f93010706c76ae4e565c06111e49ae3ede36e1bdfc08ac8R150-R152) [[3]](diffhunk://#diff-e1cc949d392fedd14f93010706c76ae4e565c06111e49ae3ede36e1bdfc08ac8R194) [[4]](diffhunk://#diff-e1cc949d392fedd14f93010706c76ae4e565c06111e49ae3ede36e1bdfc08ac8R283-R347)
* Implemented new logic to connect references after all nodes are created, ensuring all valid edges are established, including self-loops and cyclic references. [[1]](diffhunk://#diff-e1cc949d392fedd14f93010706c76ae4e565c06111e49ae3ede36e1bdfc08ac8R163) [[2]](diffhunk://#diff-e1cc949d392fedd14f93010706c76ae4e565c06111e49ae3ede36e1bdfc08ac8R283-R347)

**Expanded and improved test coverage:**

* Added a comprehensive cyclic test graph (`TEST_JSON_CYCLIC`) and new tests for self-references, suffix alias references, and cyclic edge creation, ensuring correctness of the new reference detection and edge creation logic. [[1]](diffhunk://#diff-26b05998c80f77d7cc54dc16b3e2d2bac4015270ee2e4517b2e7a4ecdc1f3f42R114-R199) [[2]](diffhunk://#diff-26b05998c80f77d7cc54dc16b3e2d2bac4015270ee2e4517b2e7a4ecdc1f3f42L285-R407)

These changes make the JSON plugin much more flexible and robust in modeling real-world graphs with complex references and relationships.